### PR TITLE
Ids printed in error

### DIFF
--- a/connector_bots/stock.py
+++ b/connector_bots/stock.py
@@ -135,7 +135,7 @@ class StockPickingIn(orm.Model):
             exported_pickings = bots_picking_obj.read(cr, uid, ids_all, ['bots_id', 'backend_id'], context=context)
             ids_all = [x['id'] for x in exported_pickings if not x['bots_id'] or not x['backend_id'] in backend_ids]
         if ids_all and doraise:
-            raise osv.except_osv(_('Error!'), _('This picking has been exported, or is pending export, to an external WMS and cannot be modified directly in OpenERP.'))
+            raise osv.except_osv(_('Error!'), _("This picking has been exported, or is pending export, to an external WMS and cannot be modified directly in OpenERP: %s".format(ids_all)))
         if ids_exported:
             res['exported'] = ids_exported
         if ids_pending:
@@ -236,7 +236,7 @@ class StockPickingOut(orm.Model):
             exported_pickings = bots_picking_obj.read(cr, uid, ids_all, ['bots_id', 'backend_id'], context=context)
             ids_all = [x['id'] for x in exported_pickings if not x['bots_id'] or not x['backend_id'] in backend_ids]
         if ids_all and doraise:
-            raise osv.except_osv(_('Error!'), _('This picking has been exported, or is pending export, to an external WMS and cannot be modified directly in OpenERP.'))
+            raise osv.except_osv(_('Error!'), _("This picking has been exported, or is pending export, to an external WMS and cannot be modified directly in OpenERP: %s".format(ids_all)))
         if ids_exported:
             res['exported'] = ids_exported
         if ids_pending:
@@ -424,7 +424,7 @@ class StockPicking(orm.Model):
                 exported_pickings = self.pool.get(MODEL).read(cr, uid, ids_all, ['bots_id', 'backend_id'], context=context)
                 ids_all = [x['id'] for x in exported_pickings if not x['bots_id'] or not x['backend_id'] in backend_ids]
             if ids_all and doraise:
-                raise osv.except_osv(_('Error!'), _('This picking has been exported, or is pending export, to an external WMS and cannot be modified directly in OpenERP.'))
+                raise osv.except_osv(_('Error!'), _("This picking has been exported, or is pending export, to an external WMS and cannot be modified directly in OpenERP: %s".format(ids_all)))
             exported.extend(ids_exported)
             pending.extend(ids_pending)
         res = {}

--- a/connector_bots/stock.py
+++ b/connector_bots/stock.py
@@ -135,7 +135,7 @@ class StockPickingIn(orm.Model):
             exported_pickings = bots_picking_obj.read(cr, uid, ids_all, ['bots_id', 'backend_id'], context=context)
             ids_all = [x['id'] for x in exported_pickings if not x['bots_id'] or not x['backend_id'] in backend_ids]
         if ids_all and doraise:
-            raise osv.except_osv(_('Error!'), _("This picking has been exported, or is pending export, to an external WMS and cannot be modified directly in OpenERP: %s".format(ids_all)))
+            raise osv.except_osv(_('Error!'), _("This picking has been exported, or is pending export, to an external WMS and cannot be modified directly in OpenERP: {0}".format(ids_all)))
         if ids_exported:
             res['exported'] = ids_exported
         if ids_pending:
@@ -236,7 +236,7 @@ class StockPickingOut(orm.Model):
             exported_pickings = bots_picking_obj.read(cr, uid, ids_all, ['bots_id', 'backend_id'], context=context)
             ids_all = [x['id'] for x in exported_pickings if not x['bots_id'] or not x['backend_id'] in backend_ids]
         if ids_all and doraise:
-            raise osv.except_osv(_('Error!'), _("This picking has been exported, or is pending export, to an external WMS and cannot be modified directly in OpenERP: %s".format(ids_all)))
+            raise osv.except_osv(_('Error!'), _("This picking has been exported, or is pending export, to an external WMS and cannot be modified directly in OpenERP: {0}".format(ids_all)))
         if ids_exported:
             res['exported'] = ids_exported
         if ids_pending:
@@ -424,7 +424,7 @@ class StockPicking(orm.Model):
                 exported_pickings = self.pool.get(MODEL).read(cr, uid, ids_all, ['bots_id', 'backend_id'], context=context)
                 ids_all = [x['id'] for x in exported_pickings if not x['bots_id'] or not x['backend_id'] in backend_ids]
             if ids_all and doraise:
-                raise osv.except_osv(_('Error!'), _("This picking has been exported, or is pending export, to an external WMS and cannot be modified directly in OpenERP: %s".format(ids_all)))
+                raise osv.except_osv(_('Error!'), _("This picking has been exported, or is pending export, to an external WMS and cannot be modified directly in OpenERP: {0}".format(ids_all)))
             exported.extend(ids_exported)
             pending.extend(ids_pending)
         res = {}


### PR DESCRIPTION
Error:
```File "/opt/openerp/production/server-addons/connector_bots/stock.py", line 531, in action_done
self.bots_test_exported(cr, uid, ids, doraise=True, context=context)
File "/opt/openerp/production/server-addons/connector_bots/stock.py", line 509, in bots_test_exported
exported = self.pool.get('stock.picking.out').bots_test_exported(cr, uid, [picking_id], doraise=doraise, cancel=cancel, context=context)
File "/opt/openerp/production/server-addons/connector_bots/stock.py", line 239, in bots_test_exported
raise osv.except_osv(_('Error!'), _('This picking has been exported, or is pending export, to an external WMS and cannot be modified directly in OpenERP.'))
except_osv: (u'Error!', u'This picking has been exported, or is pending export, to an external WMS and cannot be modified directly in OpenERP.')```