### PR TITLE
Cam 292 adding more logs

### DIFF
--- a/connector_bots/stock.py
+++ b/connector_bots/stock.py
@@ -1140,7 +1140,7 @@ def picking_available(session, model_name, record_id, picking_type, location_typ
                 )
         except Exception as e:
             logger.exception("Function 'picking_available': Error creating the stock picking "
-                             "'{type}'".format(type=picking_type, warehouse=warehouse['id']))
+                             "'{type}'".format(type=picking_type))
             raise e
 
 

--- a/connector_bots/stock.py
+++ b/connector_bots/stock.py
@@ -17,6 +17,8 @@
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 ##############################################################################
+import logging
+
 from collections import Counter
 
 from openerp.osv import orm, fields, osv
@@ -48,6 +50,9 @@ EXPORT_PICKING_PRIORITY = 3
 
 DROPSHIP_SEPARATOR = 'D'
 DROPSHIP_BACKEND = 'Dropship Shipments'
+
+
+logger = logging.getLogger(__name__)
 
 
 def get_bots_picking_ids(cr, uid, ids, ids_skipped, table, not_in_move_states, bots_id_condition, context={}):
@@ -1124,14 +1129,20 @@ def picking_available(session, model_name, record_id, picking_type, location_typ
     bots_warehouse_ids = bots_warehouse_obj.search(session.cr, session.uid, [('warehouse_id', 'in', warehouse_ids)])
     bots_warehouse = bots_warehouse_obj.browse(session.cr, session.uid, bots_warehouse_ids)
     for warehouse in bots_warehouse:
-        backend_id = bots_dropship_backend_id if picking.sp_dropship else warehouse.backend_id
+        try:
+            backend_id = bots_dropship_backend_id if picking.sp_dropship else warehouse.backend_id
 
-        if (picking_type == 'bots.stock.picking.out' and backend_id.feat_picking_out) or \
-            (picking_type == 'bots.stock.picking.in' and backend_id.feat_picking_in):
-            session.create(picking_type,
-                            {'backend_id': backend_id.id,
-                            'openerp_id': picking.id,
-                            'warehouse_id': warehouse['id'],})
+            if (picking_type == 'bots.stock.picking.out' and backend_id.feat_picking_out) \
+                    or (picking_type == 'bots.stock.picking.in' and backend_id.feat_picking_in):
+                session.create(picking_type, {
+                        'backend_id': backend_id.id, 'openerp_id': picking.id, 'warehouse_id': warehouse['id']
+                    }
+                )
+        except Exception as e:
+            logger.exception("Function 'picking_available': Error creating the stock picking "
+                             "'{type}'".format(type=picking_type, warehouse=warehouse['id']))
+            raise e
+
 
 def picking_cancel(session, model_name, record_id, picking_type):
     picking_ids = session.search(picking_type, [('openerp_id', '=', record_id)])


### PR DESCRIPTION
Ticket description: [CAM-292](https://sportpursuit.atlassian.net/browse/CAM-292)

For some reason some time a bots record is not created for a stock picking. The process does not look like there are bugs (everything looks normal, except maybe I am missing something), so the next best thing is to add some log where the stock picking is created (function `picking_available` in `connector_bots/stock.py` which trigger the bots record creation calling the function `delay_export_picking_out` in `connecto_bots/stock.py`). 

Right now I think, since it is not really a frequent bug, It could be due to some Postgres integrity error while attempting to create the `bots.stock.picking.out`. 
The new logs, hopefully, should be able to help troubleshooting the problem.
