### PR TITLE
Separate out methods for updating stock quantity

### DIFF
--- a/connector_bots_stock_integration/supplier_stock.py
+++ b/connector_bots_stock_integration/supplier_stock.py
@@ -111,7 +111,7 @@ class StockAdapter(BotsCRUDAdapter):
             today = datetime.strftime(datetime.now(), "%d-%m-%Y")
 
             products_original = product_details.products.items()
-            logger.onfo("The length of product items is: {0}".format(len(products_original)))
+            logger.info("The length of product items is: {0}".format(len(products_original)))
 
             i = 0
             n = 5000

--- a/connector_bots_stock_integration/supplier_stock.py
+++ b/connector_bots_stock_integration/supplier_stock.py
@@ -376,7 +376,7 @@ def create_physical_inventory(session, supplier, product_list, inventory_id):
         if supplier.stock_feed_threshold and 0 < qty <= supplier.stock_feed_threshold:
             qty = 0
 
-        logger.debug("Creating physical inventory for product {0}, for warehouse {1}, qty {2}".format(product_id, warehouse_id, qty))
+        logger.info("Creating physical inventory for product {0}, for warehouse {1}, qty {2}".format(product_id, warehouse_id, qty))
 
         inventory_line_record = {
             'product_uom': 1,
@@ -389,7 +389,9 @@ def create_physical_inventory(session, supplier, product_list, inventory_id):
         session.create('stock.inventory.line', inventory_line_record)
 
     inventory_obj = session.pool['stock.inventory']
+    logger.info("Confirming physical inventory {0} for stock location {1}".format(inventory_id, stock_location_id))
     inventory_obj.action_confirm(session.cr, SUPERUSER_ID, [inventory_id], session.context)
+    logger.info("Setting physical inventory {0} to 'done'".format(inventory_id))
     inventory_obj.action_done(session.cr, SUPERUSER_ID, [inventory_id], session.context)
 
     return inventory_id

--- a/connector_bots_stock_integration/supplier_stock.py
+++ b/connector_bots_stock_integration/supplier_stock.py
@@ -38,12 +38,6 @@ logger = logging.getLogger(__name__)
 SUPPLIER_STOCK_FEED = 'Supplier Stock Feed'
 
 
-def chunks(l, n):
-    """Yield successive n-sized chunks from a list l."""
-    for i in xrange(0, len(l), n):
-        yield l[i:i + n]
-
-
 class ProductDetails(object):
 
     def __init__(self):
@@ -117,8 +111,11 @@ class StockAdapter(BotsCRUDAdapter):
             today = datetime.strftime(datetime.now(), "%d-%m-%Y")
 
             i = 0
+            n = 5000
+            product_items = product_details.products.items()
+            chunks_list = [product_items[i * n:(i + 1) * n] for i in range((len(product_items) + n - 1) // n)]
 
-            for product_list in chunks(product_details.products.items(), 500):
+            for product_list in chunks_list:
 
                 i += 1
 

--- a/connector_bots_stock_integration/supplier_stock.py
+++ b/connector_bots_stock_integration/supplier_stock.py
@@ -110,15 +110,10 @@ class StockAdapter(BotsCRUDAdapter):
 
             today = datetime.strftime(datetime.now(), "%d-%m-%Y")
 
-            products_original = product_details.products.items()
-            logger.info("The length of product items is: {0}".format(len(products_original)))
-
             i = 0
             n = 5000
             product_items = product_details.products.items()
             chunks_list = [product_items[i * n:(i + 1) * n] for i in range((len(product_items) + n - 1) // n)]
-
-            logger.info("The length of chunks list is {0}".format(len(chunks_list)))
 
             for product_list in chunks_list:
 
@@ -135,8 +130,7 @@ class StockAdapter(BotsCRUDAdapter):
                                                 supplier_warehouse_id,
                                                 supplier_threshold,
                                                 product_list,
-                                                inventory_id,
-                                                priority=5)
+                                                inventory_id)
 
             for sku, barcode, quantity in product_details.missing_products:
                 # This will assign the id from the last stock inventory created to the missing products created here

--- a/connector_bots_stock_integration/supplier_stock.py
+++ b/connector_bots_stock_integration/supplier_stock.py
@@ -110,10 +110,15 @@ class StockAdapter(BotsCRUDAdapter):
 
             today = datetime.strftime(datetime.now(), "%d-%m-%Y")
 
+            products_original = product_details.products.items()
+            logger.onfo("The length of product items is: {0}".format(len(products_original)))
+
             i = 0
             n = 5000
             product_items = product_details.products.items()
             chunks_list = [product_items[i * n:(i + 1) * n] for i in range((len(product_items) + n - 1) // n)]
+
+            logger.info("The length of chunks list is {0}".format(len(chunks_list)))
 
             for product_list in chunks_list:
 


### PR DESCRIPTION
https://sportpursuit.atlassian.net/browse/CAM-706

When: A stock report was being imported to Odoo through the process_supplier_stock_file method, and the file contained a large number of changes
Then: The job was timing out and encountering concurrency errors, due to processing and approving all physical inventory lines under one physical inventory
Desired outcome: The job competes and updates the stock levels correctly

The key method of approaching this problem was to split apart the list of products for which to create physical inventories into groups of 500. The creation and approval process is then asynchronously applied to these groups rather than in synchronously in bulk.