### PR TITLE
CAM-874 Log improvements picking conf

### DIFF
--- a/connector_bots/stock_warehouse.py
+++ b/connector_bots/stock_warehouse.py
@@ -457,8 +457,7 @@ class WarehouseAdapter(BotsCRUDAdapter):
         for file_id in file_ids:
             try:
                 with file_to_process(self.session, file_id[0], new_cr=new_cr) as f:
-                    file_data = json.load(f)
-                import_picking_file.delay(self.session, model_name, record_id, picking_types, bots_file_id=file_id[0], file_data=file_data)
+                    import_picking_file.delay(self.session, model_name, record_id, picking_types, bots_file_name=file_id[1], file_data=json.load(f))
 
             except OperationalError, e:
                 # FILE_LOCK_MSG suggests that another job is already handling these files,
@@ -839,8 +838,8 @@ def import_picking_confirmation(session, model_name, record_id, picking_types, n
 
 
 @job
-def import_picking_file(session, model_name, record_id, picking_types, bots_file_id=None, file_data=None):
-    logger.info('Beginning import for bots file with id %s', bots_file_id)
+def import_picking_file(session, model_name, record_id, picking_types, bots_file_name=None, file_data=None):
+    logger.info('Beginning import for bots file %s', bots_file_name)
     warehouse = session.browse(model_name, record_id)
     backend_id = warehouse.backend_id.id
     env = get_environment(session, model_name, backend_id)

--- a/connector_bots/stock_warehouse.py
+++ b/connector_bots/stock_warehouse.py
@@ -846,6 +846,6 @@ def import_picking_file(session, model_name, record_id, picking_types, bots_file
     try:
         warehouse_importer.import_picking_file(picking_types=picking_types, file_data=file_data)
     except Exception, e:
-        exception = "Exception %s when processing file %s" % (e, bots_file_name)
+        exception = "Exception %s when processing file %s: %s" % (e, bots_file_name, traceback.format_exc())
         raise Exception(exception)
     return True

--- a/connector_bots/stock_warehouse.py
+++ b/connector_bots/stock_warehouse.py
@@ -839,10 +839,13 @@ def import_picking_confirmation(session, model_name, record_id, picking_types, n
 
 @job
 def import_picking_file(session, model_name, record_id, picking_types, bots_file_name=None, file_data=None):
-    logger.info('Beginning import for bots file %s', bots_file_name)
     warehouse = session.browse(model_name, record_id)
     backend_id = warehouse.backend_id.id
     env = get_environment(session, model_name, backend_id)
     warehouse_importer = env.get_connector_unit(BotsWarehouseImport)
-    warehouse_importer.import_picking_file(picking_types=picking_types, file_data=file_data)
+    try:
+        warehouse_importer.import_picking_file(picking_types=picking_types, file_data=file_data)
+    except Exception, e:
+        exception = "Exception %s when processing file %s" % (e, bots_file_name)
+        raise exception
     return True

--- a/connector_bots/stock_warehouse.py
+++ b/connector_bots/stock_warehouse.py
@@ -847,5 +847,5 @@ def import_picking_file(session, model_name, record_id, picking_types, bots_file
         warehouse_importer.import_picking_file(picking_types=picking_types, file_data=file_data)
     except Exception, e:
         exception = "Exception %s when processing file %s" % (e, bots_file_name)
-        raise exception
+        raise Exception(exception)
     return True


### PR DESCRIPTION
Improvements to picking conf logging
The following improvements have been made to the picking conf job:
- The name of the bots file (and not the ID) is logged, allowing CS to find the file that may need to be reimported more easily, in the case of an exception
- The exception information mirrors the previous exception information more closely
- import_picking_file takes input directly from file contents, rather than defining this in a var