### PR TITLE
Find unique picking by move id if multiple returned on picking conf import

### DIFF
--- a/connector_bots/stock_warehouse.py
+++ b/connector_bots/stock_warehouse.py
@@ -493,6 +493,21 @@ class WarehouseAdapter(BotsCRUDAdapter):
 
         return res
 
+    def get_picking_by_move(self, picking_data, binding_ids):
+        cr = self.session.cr
+        uid = self.session.uid
+        move_obj = self.session.pool.get('stock.move')
+        bots_picking_out_obj = self.session.pool.get('bots.stock.picking.out')
+        move_ids = []
+        for line in picking_data['line']:
+            move_ids.append(line['move_ids'])
+        stock_moves = move_obj.browse(cr, uid, move_ids)
+        picking_ids = list(set([move.picking_id.id for move in stock_moves]))
+        bots_ids = set(bots_picking_out_obj.search(cr, uid, [('openerp_id', 'in', picking_ids)]))
+        matching_ids = list(binding_ids & bots_ids)
+        assert len(matching_ids) == 1, "Several records found after matching stock moves: %s" % matching_ids
+        return matching_ids[0]
+
     def process_data(self, picking_types, picking_data):
 
         product_binder = self.get_binder_for_model('bots.product')
@@ -525,7 +540,18 @@ class WarehouseAdapter(BotsCRUDAdapter):
                     raise NotImplementedError("Unable to import picking of type %s" % (picking['type'],))
 
                 # Map the picking by the Bots ID/Order Number - This is used if mapping fails with the move ids
-                main_picking_id = picking_binder.to_openerp(picking['id'])
+                main_picking_list = picking_binder.to_openerp_list(picking['id'])
+                if picking['type'] == 'in':
+                    assert len(main_picking_list) == 1, "Several records found: %s" % main_picking_list
+
+                if len(main_picking_list) == 1:
+                    main_picking_id = main_picking_list[0]
+                elif len(main_picking_list) > 1:
+                    # Use the move ids in the picking data to establish the correct picking to use
+                    main_picking_id = self.get_picking_by_move(picking, main_picking_list)
+                else:
+                    main_picking_id = None
+
                 if not main_picking_id:
                     raise NoExternalId("Picking %s could not be found in OpenERP" % (picking['id'],))
                 main_picking = bots_picking_obj.browse(_cr, self.session.uid, main_picking_id, context=ctx)

--- a/connector_bots/stock_warehouse.py
+++ b/connector_bots/stock_warehouse.py
@@ -548,7 +548,7 @@ class WarehouseAdapter(BotsCRUDAdapter):
                     main_picking_id = main_picking_list[0]
                 elif len(main_picking_list) > 1:
                     # Use the move ids in the picking data to establish the correct picking to use
-                    main_picking_id = self.get_picking_by_move(picking, main_picking_list)
+                    main_picking_id = self.get_picking_by_move(picking, set(main_picking_list))
                 else:
                     main_picking_id = None
 

--- a/connector_bots/stock_warehouse.py
+++ b/connector_bots/stock_warehouse.py
@@ -500,7 +500,7 @@ class WarehouseAdapter(BotsCRUDAdapter):
         bots_picking_out_obj = self.session.pool.get('bots.stock.picking.out')
         move_ids = []
         for line in picking_data['line']:
-            move_ids.append(line['move_ids'])
+            move_ids.append(int(line['move_ids']))
         stock_moves = move_obj.browse(cr, uid, move_ids)
         picking_ids = list(set([move.picking_id.id for move in stock_moves]))
         bots_ids = set(bots_picking_out_obj.search(cr, uid, [('openerp_id', 'in', picking_ids)]))

--- a/connector_bots/unit/binder.py
+++ b/connector_bots/unit/binder.py
@@ -47,8 +47,6 @@ class BotsModelBinder(BotsBinder):
                 self.model._name,
                 [('bots_id', '=', str(external_id)),
                  ('backend_id', '=', self.backend_record.id)])
-        if not binding_ids:
-            return None
         return binding_ids
 
     def to_openerp(self, external_id, unwrap=False):

--- a/connector_bots/unit/binder.py
+++ b/connector_bots/unit/binder.py
@@ -42,6 +42,15 @@ class BotsModelBinder(BotsBinder):
     _model_name = [
         ]
 
+    def to_openerp_list(self, external_id, unwrap=False):
+        binding_ids = self.session.search(
+                self.model._name,
+                [('bots_id', '=', str(external_id)),
+                 ('backend_id', '=', self.backend_record.id)])
+        if not binding_ids:
+            return None
+        return binding_ids
+
     def to_openerp(self, external_id, unwrap=False):
         """ Give the OpenERP ID for an external ID
 


### PR DESCRIPTION
This will facilitate the import of picking confs that failed due to multiple delivery orders having the same id on bots
https://sportpursuit.atlassian.net/browse/CAM-1075